### PR TITLE
Add Laravel 12 support

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -21,6 +21,8 @@ jobs:
         laravel: [10.*, 11.*, 12.*]
         stability: [prefer-lowest, prefer-stable]
         exclude:
+          - laravel: 11.*
+            php: 8.1
           - laravel: 12.*
             php: 8.1
         include:

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Install dependencies
         run: |
           composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" "nesbot/carbon:${{ matrix.carbon }}" --no-interaction --no-update
-          composer update --${{ matrix.stability }} --prefer-dist --no-interaction --no-security-blocking
+          composer update --${{ matrix.stability }} --prefer-dist --no-interaction
 
       - name: List Installed Dependencies
         run: composer show -D

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -17,13 +17,22 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest, windows-latest]
-        php: [8.3, 8.2, 8.1]
-        laravel: [10.*]
+        php: [8.4, 8.3, 8.2, 8.1]
+        laravel: [10.*, 11.*, 12.*]
         stability: [prefer-lowest, prefer-stable]
+        exclude:
+          - laravel: 12.*
+            php: 8.1
         include:
           - laravel: 10.*
             testbench: 8.*
             carbon: ^2.63
+          - laravel: 11.*
+            testbench: 9.*
+            carbon: ^2.63|^3.0
+          - laravel: 12.*
+            testbench: 10.*
+            carbon: ^3.8
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Install dependencies
         run: |
           composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" "nesbot/carbon:${{ matrix.carbon }}" --no-interaction --no-update
-          composer update --${{ matrix.stability }} --prefer-dist --no-interaction
+          composer update --${{ matrix.stability }} --prefer-dist --no-interaction --no-security-blocking
 
       - name: List Installed Dependencies
         run: composer show -D

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -28,13 +28,13 @@ jobs:
         include:
           - laravel: 10.*
             testbench: 8.*
-            carbon: ^2.63
+            carbon: ^2.72.6
           - laravel: 11.*
             testbench: 9.*
-            carbon: ^2.63|^3.0
+            carbon: ^2.72.6|^3.8.4
           - laravel: 12.*
             testbench: 10.*
-            carbon: ^3.8
+            carbon: ^3.8.4
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
 

--- a/composer.json
+++ b/composer.json
@@ -17,21 +17,21 @@
     ],
     "require": {
         "php": "^8.1",
-        "illuminate/contracts": "^10.0|^11.0",
+        "illuminate/contracts": "^10.0|^11.0|^12.0",
         "monolog/monolog": "^3.0",
         "spatie/laravel-package-tools": "^1.14.0"
     },
     "require-dev": {
         "laravel/pint": "^1.0",
-        "nunomaduro/collision": "^7.8",
-        "larastan/larastan": "^2.0.1",
-        "orchestra/testbench": "^8.8",
-        "pestphp/pest": "^2.20",
-        "pestphp/pest-plugin-arch": "^2.0",
-        "pestphp/pest-plugin-laravel": "^2.0",
+        "nunomaduro/collision": "^7.8|^8.1",
+        "larastan/larastan": "^2.0.1|^3.0",
+        "orchestra/testbench": "^8.8|^9.0|^10.0",
+        "pestphp/pest": "^2.20|^3.0",
+        "pestphp/pest-plugin-arch": "^2.0|^3.0",
+        "pestphp/pest-plugin-laravel": "^2.0|^3.0",
         "phpstan/extension-installer": "^1.1",
-        "phpstan/phpstan-deprecation-rules": "^1.0",
-        "phpstan/phpstan-phpunit": "^1.0"
+        "phpstan/phpstan-deprecation-rules": "^1.0|^2.0",
+        "phpstan/phpstan-phpunit": "^1.0|^2.0"
     },
     "autoload": {
         "psr-4": {

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -8,5 +8,4 @@ parameters:
     tmpDir: build/phpstan
     checkOctaneCompatibility: true
     checkModelProperties: true
-    checkMissingIterableValueType: false
 


### PR DESCRIPTION
## Summary
- Widen `illuminate/contracts` to allow `^12.0` alongside existing `^10.0|^11.0`
- Widen dev tooling (`orchestra/testbench`, `pestphp/pest*`, `nunomaduro/collision`, `larastan/larastan`, `phpstan/phpstan-*`) to versions compatible with Laravel 12 / Testbench 10 / PHPStan 2, while keeping existing L10/L11 ranges working
- Drop `checkMissingIterableValueType: false` from `phpstan.neon.dist` — this parameter was removed in PHPStan 2 (used by Larastan 3) and caused an "invalid configuration" error; it had no effect at the project's analysis level 5 anyway
- Add Laravel 11.x/12.x to the CI matrix (previously only 10.x was actually tested despite the package already declaring L11 support), add PHP 8.4, and exclude PHP 8.1 + Laravel 12 (Laravel 12 requires PHP >=8.2)

No source code changes were needed — `AxiomLogHandler`/`AxiomServiceProvider` only use Monolog and Spatie's package-tools abstraction, neither of which changed in a way that affects this package for Laravel 12.

## Test plan
- [x] `composer update` resolves cleanly against `laravel/framework:12.*` + `orchestra/testbench:^10.0`; `vendor/bin/pest --ci` passes
- [x] `vendor/bin/phpstan analyse` passes clean on the Laravel 12 / PHPStan 2 toolchain
- [x] `composer update --prefer-lowest` against `laravel/framework:10.*` still resolves and `vendor/bin/pest --ci` passes (no regression for existing supported versions)